### PR TITLE
feat: Fancier dark/light mode toggler with gradient coloring and sunset animation

### DIFF
--- a/src/themes/components/ModeToggle.jsx
+++ b/src/themes/components/ModeToggle.jsx
@@ -1,19 +1,64 @@
-import {useColorMode, Button, Tooltip } from "@chakra-ui/react";
+import {useColorMode, Box, Tooltip } from "@chakra-ui/react";
 import { PiSunDuotone, PiMoonStarsDuotone } from 'react-icons/pi'
 
+/* // 1. Import `extendTheme`
+import { extendTheme } from '@chakra-ui/react'
+
+// 2. Extend the theme with new layer styles
+const sunset = extendTheme({
+  layerStyles: {
+    _dark: {
+      backgroundPosition: 'top',
+      transition: '0.8s'
+    },
+    _light: {
+      backgroundPosition: 'bottom',
+      transition: '0.8s'
+    },
+  },
+})
+ */
 const Toggle = () => {
   const { colorMode, toggleColorMode } = useColorMode();
 
   return (
     <div>
     <Tooltip label={`Toggle to ${colorMode === "light" ? "Dark" : "Light"} Mode`}>
-      <Button
+      <Box as='button'
+          padding={4}
           aria-label="Toggle Color Mode"
           onClick={toggleColorMode}
-          _focus={{ boxShadow: 'none' }}
-          w="fit-content">
-          {colorMode === 'light' ? <PiMoonStarsDuotone /> : <PiSunDuotone />}
-        </Button>
+          boxShadow= 'none'
+          _focus={{  }}
+          bgGradient = 'linear(to-b, #030033 0%, #611b87 35%, #5570cc 69%, #5abaf0 77%, #fff8e9 100%)'
+          backgroundSize = "auto 300%"
+          _hover =
+            {{backgroundPosition: 'center',
+            transition: '0.5s'
+            }}
+            //FIXME: Remove line appearing on ends of gradient
+            //TODO: Add animations on Hover (transform scale) and on change (Sun dawning and Moon descending). Also maybe improve icon coloring selection.
+          _dark={{
+            backgroundPosition: 'top',
+            transition: '0.8s',
+            _hover: {
+              backgroundPosition: 'center',
+              transition: '0.5s'
+            }
+          }}
+          _light={{
+            backgroundPosition: 'bottom',
+            transition: '0.8s',
+            _hover: {
+              backgroundPosition: 'center',
+              transition: '0.5s'
+            }
+          }}
+          >
+          {colorMode === 'light' 
+            ? <PiSunDuotone color = "yellow"/> 
+            : <PiMoonStarsDuotone color = "white" />}
+        </Box>
     </Tooltip>
     </div>
   );


### PR DESCRIPTION
As an excuse to practice animations, transitions and gradients I implemented this idea I had when I first started working on the mode toggler: on dark mode, the moon is backed with night-sky coloring; on light mode, the sun is backed with daylight coloring; finally, when hovering, the coloring will be that of sunset, so transition from one to another simulates day-to-night color cycles seamlessly.