### PR TITLE
feat: Improved mode toggler

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,8 +15,6 @@ function App() {
           <Card> Test </Card>
           <br></br>
           <SimpleGrid 
-            flexShrink={0}
-            align = 'stretch'
             spacing = {4} 
             columns={{base: 1, sm: 1, md: 2}}> {/* If screen about the size of a phone (portrait), 1 column. Otherwise, 2 of them*/}
             <CustomCard {...cards.TEMPLATE}/>

--- a/src/themes/components/Header.jsx
+++ b/src/themes/components/Header.jsx
@@ -1,4 +1,4 @@
-import { Flex, Center } from '@chakra-ui/react'
+import { ButtonGroup } from '@chakra-ui/react'
 //Box, Text, Button, Menu, MenuButton, MenuList, MenuItem, MenuDivider, Stack, Center
 import  Toggle  from './ModeToggle'
 import ToneSelector from './ToneSelector'
@@ -10,17 +10,11 @@ import TempoSelector from './TempoSelector'
 
 const Header = () => {
     return (
-        <Flex zIndex={2} width='100%' alignItems={'center'} justifyContent={'space-between'}>
-            <Center>
-                <Toggle />
-            </Center>
-            <Center>
-                <ToneSelector />
-            </Center>
-            <Center>
-                <TempoSelector />
-            </Center>
-        </Flex>
+        <ButtonGroup display='flex' justifyContent='space-between'>
+            <Toggle />
+            <ToneSelector />
+            <TempoSelector />
+        </ButtonGroup>
     )
 }
 

--- a/src/themes/components/ModeToggle.jsx
+++ b/src/themes/components/ModeToggle.jsx
@@ -4,38 +4,65 @@ import { PiSunDuotone, PiMoonStarsDuotone } from 'react-icons/pi'
 const Toggle = () => {
   const { colorMode, toggleColorMode } = useColorMode();
 
+  const CYCLE = [
+    /* Night */
+    '#9024D0 0%',
+    '#4851C9 15%',
+    /* Sunrise */
+    '#788cf3 26%',
+    '#A5C9F0 35%',
+    '#DEB262 38%',
+    '#E58C4D 39%',
+    '#F34325 40%',
+    /*Sunset */
+    '#21023D 45%',
+    '#681853 57%',
+    '#FA4E39 67%',
+    '#F6E473 70%',
+    /* Day  */
+    '#021A9A 75%',
+    '#2f92f4 87%',
+    '#0293ea 95%'
+  ];
+
+  const POS = {
+    night:    '50% 1%' ,
+    sunrise:  '50% 20%',
+    sunset:   '50% 60%',
+    day:      '50% 99%'  
+  };
+
+  // TODO: Find a way to animate from hovered initial state to unhovered next state (without scroll effect and without initial unhovered state)
+
   return (
     <div>
-    <Tooltip label={`Toggle to ${colorMode === "light" ? "Dark" : "Light"} Mode`}>
+    <Tooltip label = {`Toggle to ${colorMode === "light" ? "Dark" : "Light"} Mode`}>
       <Box as='button'
-          padding={4}
+          p = {3}
+          fontSize='20'
+          text-align = 'center'
+          display = 'flex'
+          alignContent = 'center'
+          justifyContent= 'flex-center'
           aria-label="Toggle Color Mode"
           onClick={toggleColorMode}
           boxShadow= 'none'
-          _focus={{  }}
-          bgGradient = 'linear(to-b, #030033 0%, #611b87 35%, #5570cc 69%, #5abaf0 77%, #fff8e9 100%)'
-          backgroundSize = "auto 300%"
-            //FIXME: Remove line appearing on ends of gradient
-            //TODO: Add animations on Hover (transform scale) and on change (Sun dawning and Moon descending). Also maybe improve icon coloring selection.
-          _dark={{
-            backgroundPosition: 'top',
-            transition: '0.8s',
-            _hover: {
-              backgroundPosition: 'center',
-              transition: '0.5s'
-            }
-          }}
-          _light={{
-            backgroundPosition: 'bottom',
-            transition: '0.8s',
-            _hover: {
-              backgroundPosition: 'center',
-              transition: '0.5s'
-            }
-          }}
+          transition= '0.8s '
+          // Full "sky" gradient, with all four modes
+          bgGradient = { `linear(to-b, ${CYCLE})` }
+          backgroundSize = "auto 400%"          
+          /* --- COLOR CHANGING UPON MODE TOGGLE --- */
+          _hover = {{
+              transition: '0.7s',
+              ease: "easeInOut",
+              _dark: { backgroundPosition: POS.sunrise },
+              _light: { backgroundPosition: POS.sunset },
+            }}
+          _dark = {{ backgroundPosition: POS.night }}
+          _light = {{ backgroundPosition: POS.day  }}
           >
           {colorMode === 'light' 
-            ? <PiSunDuotone color = "yellow"/> 
+            ? <PiSunDuotone color = "#FFFFA3"/> 
             : <PiMoonStarsDuotone color = "white" />}
         </Box>
     </Tooltip>


### PR DESCRIPTION
Mode toggler now has a background made up of 4 steps instead of initial 3, corresponding to night, sunrise, day and sunset. Changed colors and the gradients' details to get it to be more similar to the sky's colors in these four stages, and also to make sure all of them had a 3:1 contrast ratio against the web's background color and against its icon. Gradient steps and stage positions have been saved as constants 
in order to imrpove code readability.
Header has been groupped in a button group, too.