### PR TITLE
feat: Slider theming with preset SliderMark props

### DIFF
--- a/src/components/ToneSlider.jsx
+++ b/src/components/ToneSlider.jsx
@@ -2,41 +2,28 @@ import { Slider, SliderTrack, SliderThumb, SliderMark } from '@chakra-ui/react'
 import { Box } from '@chakra-ui/react';
 import { useState } from 'react';
 import { KEY } from '../resources/constants';
+import { topMark, bottomMark } from '../themes/sliderTheme';
 
 const ToneSlider = () => {
 
     const [sliderValue, setSliderValue] = useState(0)
 
-    const labelStyles = {
-        marginLeft: '-1',
-        marginTop: '2',
-        fontSize: 'sm',
-        textAlign: 'center',
-    }
-
     let symbol = (sliderValue) => {
         if      (sliderValue < 0) { return '♭' }
         else if (sliderValue > 0) { return '♯' }
-        else { return '♮' }
+        else                      { return '♮' }
     }
 
 return (
     <Box marginBottom = { 5 } marginTop = { 10 } >
         <Slider defaultValue = { 0 } min = { -6 } max = { 6 } step = { 1 } aria-label='key-selection-slider' onChange={(val) => setSliderValue(val)}>
-            <SliderTrack bg = 'primary.500'/>
-            <SliderMark value = { 0 } {...labelStyles}  >♮</SliderMark>
-            <SliderMark value = { -6 } {...labelStyles} >♭</SliderMark>
-            <SliderMark value = { 6 } {...labelStyles}  >♯</SliderMark>
             <SliderTrack />
-            <SliderThumb boxSize = { 3 } />
-            <SliderMark
-                value = { sliderValue }
-                textAlign = 'center'
-                bg = 'primary.500'
-                color = 'white'
-                mt = '-10'
-                ml = '-5'
-                w = '10' >
+            <SliderThumb />
+            <SliderMark value = { 0 }   {...bottomMark} >♮</SliderMark>
+            <SliderMark value = { -6 }  {...bottomMark} >♭</SliderMark>
+            <SliderMark value = { 6 }   {...bottomMark} >♯</SliderMark>
+            <SliderTrack />
+            <SliderMark value = { sliderValue } {...topMark} >
                 {Math.abs(sliderValue)}{symbol(sliderValue)}
             </SliderMark>
         </Slider>

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -7,6 +7,7 @@ import { tooltipTheme } from './tooltipTheme'
 import { buttonTheme } from './buttonTheme'
 import { popoverTheme } from './popoverTheme'
 import { drawerTheme } from './drawerTheme'
+import { sliderTheme } from './sliderTheme'
 
 // TODO: Change background color for modal
 
@@ -40,6 +41,7 @@ const customTheme = extendTheme(
         Button: buttonTheme,
         Popover: popoverTheme,
         Drawer: drawerTheme,
+        Slider: sliderTheme,
       },
   },
   withDefaultColorScheme({ colorScheme: 'primary' }),

--- a/src/themes/sliderTheme.js
+++ b/src/themes/sliderTheme.js
@@ -1,0 +1,39 @@
+import { sliderAnatomy as parts } from "@chakra-ui/anatomy";
+import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
+import { mode } from "@chakra-ui/theme-tools";
+
+
+const { definePartsStyle, defineMultiStyleConfig } =
+    createMultiStyleConfigHelpers(parts.keys);
+
+const baseStyle = definePartsStyle((props) => ({
+    track: {
+        bg: mode("primary.400", "primary.300")(props),
+    },
+    thumb: {
+        boxSize: '3',
+    },
+    mark: {
+        textAlign: 'center',
+    },
+}));
+
+export const sliderTheme = defineMultiStyleConfig({
+    baseStyle,
+});
+
+
+//slidermark cannot have variant definitions by itself, so I'd rather have the props saved on the same place
+export const bottomMark = {
+    marginLeft: '-1',
+    marginTop: '2',
+    fontSize: 'sm',
+};
+
+export const topMark = {
+    marginLeft: '-5',
+    marginTop: '-10',
+    background: 'primary.500',
+    color: 'white',
+    width: '10'
+};


### PR DESCRIPTION
SliderMark cannot have variants by itself (afaik), so in order to keep the Tone Slider file clean I stored the props as constants that can be exported as shortcut; that way I can centralize their theming, too.
